### PR TITLE
Handle passing additional arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,5 @@ pages.first.number
 pages.first.text
 => "The text of the PDF"
 ```
+
+Both methods take an optional hash of command line arguments to pass to `pdftotext`. The only one by default being `-layout`.

--- a/lib/pdftotext/cli.rb
+++ b/lib/pdftotext/cli.rb
@@ -8,7 +8,7 @@ module Pdftotext
     def run_command(*args)
       options = DEFAULT_OPTIONS.merge(args.pop)
       args = args.concat options_to_args(options)
-      output, status = Open3.capture2e(bin_path, *args)
+      output, status = Open3.capture2e("#{bin_path} #{args.join(" ")}")
       raise "Command `#{bin_path} #{args.join(" ")}` failed: #{output}" if status.exitstatus != 0
       output
     end

--- a/lib/pdftotext/cli.rb
+++ b/lib/pdftotext/cli.rb
@@ -8,7 +8,7 @@ module Pdftotext
     def run_command(*args)
       options = DEFAULT_OPTIONS.merge(args.pop)
       args = args.concat options_to_args(options)
-      output, status = Open3.capture2e("#{bin_path} #{args.join(" ")}")
+      output, status = Open3.capture2e(bin_path, *args)
       raise "Command `#{bin_path} #{args.join(" ")}` failed: #{output}" if status.exitstatus != 0
       output
     end

--- a/lib/pdftotext/cli.rb
+++ b/lib/pdftotext/cli.rb
@@ -23,11 +23,8 @@ module Pdftotext
       args = []
       options.each do |key, value|
         next if value === false
-        if value === true
-          args.push "-#{key}"
-        else
-          args.push "-#{key} #{value}"
-        end
+        args.push "-#{key}"
+        args.push value.to_s unless value === true
       end
       args
     end

--- a/lib/pdftotext/version.rb
+++ b/lib/pdftotext/version.rb
@@ -1,3 +1,3 @@
 module Pdftotext
-  VERSION = "0.2.0"
+  VERSION = "0.2.1"
 end

--- a/spec/pdftotext_cli_spec.rb
+++ b/spec/pdftotext_cli_spec.rb
@@ -8,7 +8,7 @@ describe Pdftotext::CLI do
   it "converts options to args" do
     options = {:foo => true, :bar => false, :page => 1}
     args = subject.send(:options_to_args, options)
-    expect(args).to eql(["-foo", "-page 1"])
+    expect(args).to eql(["-foo", "-page", "1"])
   end
 
   it "runs a command" do

--- a/spec/pdftotext_document_spec.rb
+++ b/spec/pdftotext_document_spec.rb
@@ -23,4 +23,9 @@ describe Pdftotext::Document do
     expect(pages.last.text).to eql("This is another test.\n")
     expect(pages.last.number).to eql(2)
   end
+
+  it "respects non-default command line arguments" do
+    pages = subject.pages({l: 1})
+    expect(pages.count).to eql(1)
+  end
 end


### PR DESCRIPTION
Trying to run `Pdftotext('../path/to/file', {fixed: 2})` resulted in an error and caused the help text for `pdftotext` to be printed. Changing the call to `Open3` to make the command a single string worked to fix this problem for me.
